### PR TITLE
Add rules for Mocha

### DIFF
--- a/packages/eslint-config-base/index.js
+++ b/packages/eslint-config-base/index.js
@@ -12,6 +12,9 @@ module.exports = {
     es2020: true, // Add all ECMAScript 2020 globals and automatically set the ecmaVersion parser option to ES2020
   },
 
-  extends: ['./rules/imports'].map(require.resolve),
+  extends: [
+    './rules/imports',
+    './rules/mocha',
+  ].map(require.resolve),
   rules: {},
 }

--- a/packages/eslint-config-base/package-lock.json
+++ b/packages/eslint-config-base/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "1.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -535,6 +535,27 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true
+        }
+      }
+    },
+    "eslint-plugin-mocha": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-mocha/-/eslint-plugin-mocha-6.3.0.tgz",
+      "integrity": "sha512-Cd2roo8caAyG21oKaaNTj7cqeYRWW1I2B5SfpKRp0Ip1gkfwoR1Ow0IGlPWnNjzywdF4n+kHL8/9vM6zCJUxdg==",
+      "dev": true,
+      "requires": {
+        "eslint-utils": "^2.0.0",
+        "ramda": "^0.27.0"
+      },
+      "dependencies": {
+        "eslint-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
         }
       }
     },
@@ -1447,6 +1468,12 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "ramda": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.0.tgz",
+      "integrity": "sha512-pVzZdDpWwWqEVVLshWUHjNwuVP7SfcmPraYuqocJp1yo2U1R7P+5QAfDhdItkuoGqIBnBYrtPp7rEPqDn9HlZA==",
       "dev": true
     },
     "read-pkg": {

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -23,12 +23,14 @@
   "dependencies": {},
   "peerDependencies": {
     "eslint": ">= 6",
-    "eslint-plugin-import": "^2.20.1"
+    "eslint-plugin-import": "^2.20.1",
+    "eslint-plugin-mocha": "^6.3.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",
     "eslint-find-rules": "^3.4.0",
     "eslint-plugin-import": "^2.20.1",
+    "eslint-plugin-mocha": "^6.3.0",
     "prettier": "^2.0.2"
   }
 }

--- a/packages/eslint-config-base/rules/mocha.js
+++ b/packages/eslint-config-base/rules/mocha.js
@@ -1,0 +1,75 @@
+module.exports = {
+  env: {
+    node: true, // Enable node global variables & Node.js scoping
+    es2020: true, // Add all ECMAScript 2020 globals and automatically set the ecmaVersion parser option to ES2020
+  },
+  parserOptions: {
+    sourceType: 'module',
+  },
+
+  plugins: ['mocha'],
+  extends: ['plugin:mocha/recommended'],
+
+  // These rules are not captured in the standard recommended configuration we extend above.
+  rules: {
+    // For our Mocha test files, the pattern is to have unnamed functions
+    // https://eslint.org/docs/rules/func-names
+    'func-names': 'off',
+
+    // Hooks should only be declared inside test suites, as they would otherwise be run before or after every test or test suite of the project.
+    // This can lead to very confusing and unwanted effects.
+    // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-top-level-hooks.md
+    'mocha/no-top-level-hooks': 'error',
+
+    // Disallow setup in describe blocks
+    // https://github.com/lo1tuma/eslint-plugin-mocha/blob/1e32ad7bffb25c249cdd81ff3cb0d1a775d3dfe7/docs/rules/no-setup-in-describe.md
+    // TODO: may be worth specifying an override for this rule for unit tests where we dynamically generate the test cases:
+    // https://mochajs.org/#dynamically-generating-tests
+    'mocha/no-setup-in-describe': 'error',
+
+    /* DISABLED RULES */
+
+    // Hooks allow code to be run before or after every or all tests which helps define a common setup or teardown process for every test.
+    //The use of these hooks promotes the use of shared state between the tests, and defeats the purpose of having isolated unit tests.
+    // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-hooks.md
+    // TODO: Maybe enable this rule for a `unit` subdirectory of the test directory.
+    'mocha/no-hooks': 'off',
+
+    // Reports when the function is async and returns a value.
+    // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-return-from-async.md
+    'mocha/no-return-from-async': 'off',
+
+    // Match suite descriptions against a pre-configured regular expression.
+    // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/valid-suite-description.md
+    'mocha/valid-suite-description': 'off',
+
+    // Match test descriptions against a pre-configured regular expression
+    // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/valid-test-description.md
+    'mocha/valid-test-description': 'off',
+
+    // When writing tests for an asynchronous function, omitting the done callback or forgetting to return a promise can often lead to false-positive test cases.
+    // This rule warns against the implicit synchronous feature, and should be combined with handle-done-callback for best results.
+    // https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-synchronous-tests.md
+    'mocha/no-synchronous-tests': 'off',
+  },
+
+  overrides: [
+    {
+      files: ['test/**/*.test.ts'],
+      env: {
+        mocha: true, // Global variables for mocha
+      },
+      rules: {
+        // Require using arrow functions for callbacks.
+        // This rule is a variation of the core eslint prefer-arrow-callback rule that is mocha-aware and does not flag non-arrow callbacks within mocha functions.
+        // https://github.com/lo1tuma/eslint-plugin-mocha/blob/1e32ad7bffb25c249cdd81ff3cb0d1a775d3dfe7/docs/rules/prefer-arrow-callback.md
+        'prefer-arrow-callback': 'off',
+        'mocha/prefer-arrow-callback': 'error',
+
+        // It's reasonable to have hooks for single cases for when the describe block grows and more tests get added to that case.
+        // https://github.com/lo1tuma/eslint-plugin-mocha/blob/1e32ad7bffb25c249cdd81ff3cb0d1a775d3dfe7/docs/rules/no-hooks-for-single-case.md
+        'mocha/no-hooks-for-single-case': 'off',
+      },
+    },
+  ],
+}


### PR DESCRIPTION
## High Level Overview of Change

Add rules for the [Mocha ESLint plugin](https://github.com/lo1tuma/eslint-plugin-mocha).

It might be worth adding a Jest configuration to this repo later on, but right now, all our Node-based server-side projects or libraries use Mocha, so this seems like the right test library plugin for now.

### Context of Change

Part of the general process of setting up a shared ESLint configuration for all our Node-based TypeScript projects.

### Rules Worth Discussing

#### `mocha/no-setup-in-describe`

This rule is enabled right now, with a violation of `error`.

This rule disallows any setup code in a `describe` block, which is normally reasonable, but if we were [dynamically generating test cases](https://mochajs.org/#dynamically-generating-tests), which we might do for unit tests, that would violate this rule, so it might be worth disabling for a `unit` test subdirectory.

#### `mocha/no-hooks`

This rule is disabled right now.

This rule completely disallows hooks like `before/beforeEach/after/afterEach`. This is normally a _bad_ rule, but since this creates shared state between tests, for a subdirectory that contained _only unit tests_, it might be worth enabling.

https://github.com/lo1tuma/eslint-plugin-mocha/blob/master/docs/rules/no-hooks.md 

### Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Before / After

Now `mocha` plugin related configuration can be removed from repos using `@xpring-eng/eslint-config-base`.

## Test Plan

- Run `npm link` inside this repo
- In the `payid` repo, run `npm link @xpring-eng/eslint-config-base`
- Add `@xpring-eng/eslint-config-base` to the bottom of the extends[] array in the `.eslintrc.js` in the `payid` repo
- Remove all mocha-associated rules from the PayID ESLint config and assert that rules from @xpring-eng/eslint-config-base are being used correctly.

<!--
## Future Tasks
For future tasks related to PR.
-->
