### PR TITLE
version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [Unreleased]
 
+## 0.2.3 - May 21, 2020
+
+- Bump `eslint-plugin-tsdoc` from 0.2.4 to 0.2.5
+  - Add support for the `@see` tag!
 - Increase cyclomatic `complexity` threshold from 8 to 10
+  - Seems to be the typical standard
 
 ## 0.2.2 - May 19, 2020
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Xpring's base TS ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Bump `eslint-plugin-tsdoc` from 0.2.4 to 0.2.5
  - Add support for the `@see` tag!
- Increase cyclomatic `complexity` threshold from 8 to 10	- Increase cyclomatic `complexity` threshold from 8 to 10
  - Seems to be the typical standard