### PR TITLE
0.3.0 - Upgrade `@typescript-eslint`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [Unreleased]
 
+## 0.3.0 - May 26, 2020
+
+- Upgrade `@typescript-eslint` to 3.0.1
+  - Update corresponding rules and options
+- Fix bug introduced by using StrictPascalCase for enum members
+- Change severity of TS rules to match `@typescript-eslint` recommendations
+
 ## 0.2.3 - May 21, 2020
 
 - Bump `eslint-plugin-tsdoc` from 0.2.4 to 0.2.5

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,12 +109,12 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.0.0.tgz",
-      "integrity": "sha512-lcZ0M6jD4cqGccYOERKdMtg+VWpoq3NSnWVxpc/AwAy0zhkUYVioOUZmfNqiNH8/eBNGhCn6HXd6mKIGRgNc1Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.0.1.tgz",
+      "integrity": "sha512-RxGldRQD3hgOK2xtBfNfA5MMV3rn5gVChe+MIf14hKm51jO2urqF64xOyVrGtzThkrd4rS1Kihqx2nkSxkXHvA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "3.0.0",
+        "@typescript-eslint/experimental-utils": "3.0.1",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
         "semver": "^7.3.2",
@@ -130,33 +130,33 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.0.0.tgz",
-      "integrity": "sha512-BN0vmr9N79M9s2ctITtChRuP1+Dls0x/wlg0RXW1yQ7WJKPurg6X3Xirv61J2sjPif4F8SLsFMs5Nzte0WYoTQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.0.1.tgz",
+      "integrity": "sha512-GdwOVz80MOWxbc/br1DC30eeqlxfpVzexHgHtf3L0hcbOu1xAs1wSCNcaBTLMOMZbh1gj/cKZt0eB207FxWfFA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "3.0.0",
+        "@typescript-eslint/typescript-estree": "3.0.1",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.0.0.tgz",
-      "integrity": "sha512-8RRCA9KLxoFNO0mQlrLZA0reGPd/MsobxZS/yPFj+0/XgMdS8+mO8mF3BDj2ZYQj03rkayhSJtF1HAohQ3iylw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.0.1.tgz",
+      "integrity": "sha512-Pn2tDmOc4Ri93VQnT70W0pqQr6i/pEZqIPXfWXm4RuiIprL0t6SG13ViVXHgfScknL2Fm2G4IqXhUzxSRCWXCw==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "3.0.0",
-        "@typescript-eslint/typescript-estree": "3.0.0",
+        "@typescript-eslint/experimental-utils": "3.0.1",
+        "@typescript-eslint/typescript-estree": "3.0.1",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.0.0.tgz",
-      "integrity": "sha512-nevQvHyNghsfLrrByzVIH4ZG3NROgJ8LZlfh3ddwPPH4CH7W4GAiSx5qu+xHuX5pWsq6q/eqMc1io840ZhAnUg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.0.1.tgz",
+      "integrity": "sha512-FrbMdgVCeIGHKaP9OYTttFTlF8Ds7AkjMca2GzYCE7pVch10PAJc1mmAFt+DfQPgu/2TrLAprg2vI0PK/WTdcg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,45 +109,54 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz",
-      "integrity": "sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.0.0.tgz",
+      "integrity": "sha512-lcZ0M6jD4cqGccYOERKdMtg+VWpoq3NSnWVxpc/AwAy0zhkUYVioOUZmfNqiNH8/eBNGhCn6HXd6mKIGRgNc1Q==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.34.0",
+        "@typescript-eslint/experimental-utils": "3.0.0",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
+        "semver": "^7.3.2",
         "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        }
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
-      "integrity": "sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.0.0.tgz",
+      "integrity": "sha512-BN0vmr9N79M9s2ctITtChRuP1+Dls0x/wlg0RXW1yQ7WJKPurg6X3Xirv61J2sjPif4F8SLsFMs5Nzte0WYoTQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.34.0",
+        "@typescript-eslint/typescript-estree": "3.0.0",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.34.0.tgz",
-      "integrity": "sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.0.0.tgz",
+      "integrity": "sha512-8RRCA9KLxoFNO0mQlrLZA0reGPd/MsobxZS/yPFj+0/XgMdS8+mO8mF3BDj2ZYQj03rkayhSJtF1HAohQ3iylw==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.34.0",
-        "@typescript-eslint/typescript-estree": "2.34.0",
+        "@typescript-eslint/experimental-utils": "3.0.0",
+        "@typescript-eslint/typescript-estree": "3.0.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
-      "integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.0.0.tgz",
+      "integrity": "sha512-nevQvHyNghsfLrrByzVIH4ZG3NROgJ8LZlfh3ddwPPH4CH7W4GAiSx5qu+xHuX5pWsq6q/eqMc1io840ZhAnUg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -27,25 +27,25 @@
     "eslint-config-prettier": "^6.11.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.34.0",
-    "@typescript-eslint/parser": "^2.34.0",
+    "@typescript-eslint/eslint-plugin": "^3.0.0",
+    "@typescript-eslint/parser": "^3.0.0",
     "eslint": ">= 7",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-mocha": "^7.0.0",
     "eslint-plugin-prettier": "^3.1.3",
-    "eslint-plugin-tsdoc": "^0.2.4",
+    "eslint-plugin-tsdoc": "^0.2.5",
     "prettier": "^2.0.5",
     "typescript": "^3.9.2"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.34.0",
-    "@typescript-eslint/parser": "^2.34.0",
+    "@typescript-eslint/eslint-plugin": "^3.0.0",
+    "@typescript-eslint/parser": "^3.0.0",
     "eslint": "^7.0.0",
     "eslint-find-rules": "^3.4.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-mocha": "^7.0.0",
     "eslint-plugin-prettier": "^3.1.3",
-    "eslint-plugin-tsdoc": "^0.2.4",
+    "eslint-plugin-tsdoc": "^0.2.5",
     "prettier": "^2.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Xpring's base TS ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "eslint-config-prettier": "^6.11.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.0.0",
-    "@typescript-eslint/parser": "^3.0.0",
+    "@typescript-eslint/eslint-plugin": "^3.0.1",
+    "@typescript-eslint/parser": "^3.0.1",
     "eslint": ">= 7",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-mocha": "^7.0.0",
@@ -38,8 +38,8 @@
     "typescript": "^3.9.2"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.0.0",
-    "@typescript-eslint/parser": "^3.0.0",
+    "@typescript-eslint/eslint-plugin": "^3.0.1",
+    "@typescript-eslint/parser": "^3.0.1",
     "eslint": "^7.0.0",
     "eslint-find-rules": "^3.4.0",
     "eslint-plugin-import": "^2.20.2",

--- a/rules/@typescript-eslint.js
+++ b/rules/@typescript-eslint.js
@@ -475,7 +475,7 @@ module.exports = {
         allowNumber: true,
         allowBoolean: true,
         allowAny: false,
-        allowNullable: false,
+        allowNullish: false,
       },
     ],
 

--- a/rules/@typescript-eslint.js
+++ b/rules/@typescript-eslint.js
@@ -232,7 +232,7 @@ module.exports = {
 
     // Disallow the use of eval()-like methods.
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-implied-eval.md
-    '@typescript-eslint/no-implied-eval': 'warn',
+    '@typescript-eslint/no-implied-eval': 'error',
 
     // Disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-inferrable-types.md
@@ -354,22 +354,22 @@ module.exports = {
     // Disallows assigning any to variables and properties
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unsafe-assignment.md
     // TODO: ERROR?
-    '@typescript-eslint/no-unsafe-assignment': 'warn',
+    '@typescript-eslint/no-unsafe-assignment': 'error',
 
     // Disallows calling (function calls) on an `any` type value.
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unsafe-call.md
     // TODO: ERROR?
-    '@typescript-eslint/no-unsafe-call': 'warn',
+    '@typescript-eslint/no-unsafe-call': 'error',
 
     // Disallows member access on an `any` type value.
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unsafe-member-access.md
     // TODO: ERROR?
-    '@typescript-eslint/no-unsafe-member-access': 'warn',
+    '@typescript-eslint/no-unsafe-member-access': 'error',
 
     // Disallows returning an `any` type value from a function.
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unsafe-return.md
     // TODO: ERROR?
-    '@typescript-eslint/no-unsafe-return': 'warn',
+    '@typescript-eslint/no-unsafe-return': 'error',
 
     // Disallow unused variables and arguments (experimental, uses TypeScript type information.)
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars-experimental.md

--- a/rules/@typescript-eslint.js
+++ b/rules/@typescript-eslint.js
@@ -339,10 +339,7 @@ module.exports = {
     '@typescript-eslint/no-unnecessary-condition': [
       'error',
       {
-        // Allow using && and || for short-circuiting behavior
-        ignoreRhs: true,
         allowConstantLoopConditions: false,
-        checkArrayPredicates: true,
       },
     ],
 
@@ -420,7 +417,6 @@ module.exports = {
       {
         ignoreConditionalTests: true,
         ignoreMixedLogicalExpressions: true,
-        forceSuggestionFixer: false,
       },
     ],
 

--- a/rules/@typescript-eslint.js
+++ b/rules/@typescript-eslint.js
@@ -706,6 +706,7 @@ module.exports = {
 
     // Restricts the types allowed in boolean expressions (ternary, if statements, &&, ||, ...)
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/strict-boolean-expressions.md
+    // TODO: This rule may be worth re-visiting now that @typescript-eslint v3.0.0 has completely reworked it
     '@typescript-eslint/strict-boolean-expressions': [
       'off',
       {
@@ -728,6 +729,7 @@ module.exports = {
       files: ['test/**/*.test.ts'],
       rules: {
         // No need to handle promise exceptions in test blocks, since they'll just be handled anyways.
+        // TODO:(hbergren) Is this true?
         '@typescript-eslint/no-floating-promises': 'off',
 
         // We purposefully break some TypeScript assumptions in various tests (like giving `null` to a database access function)

--- a/rules/@typescript-eslint.js
+++ b/rules/@typescript-eslint.js
@@ -206,12 +206,15 @@ module.exports = {
 
     // Forbids the use of classes as namespaces.
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-extraneous-class.md
-    '@typescript-eslint/no-extraneous-class': ['error', {
+    '@typescript-eslint/no-extraneous-class': [
+      'error',
+      {
       allowConstructorOnly: false,
       allowEmpty: false,
       allowStaticOnly: false,
       allowWithDecorator: false,
-    }],
+      },
+    ],
 
     // Requires Promise-like values to be handled appropriately.
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-floating-promises.md

--- a/rules/@typescript-eslint.js
+++ b/rules/@typescript-eslint.js
@@ -163,7 +163,7 @@ module.exports = {
       // Enforce that enumMembers are PascalCase
       {
         selector: 'enumMember',
-        format: ['StrictPascalCase', 'UPPER_CASE'],
+        format: ['PascalCase', 'UPPER_CASE'],
       },
       // Allow property names to be snake_case
       {

--- a/rules/@typescript-eslint.js
+++ b/rules/@typescript-eslint.js
@@ -209,10 +209,10 @@ module.exports = {
     '@typescript-eslint/no-extraneous-class': [
       'error',
       {
-      allowConstructorOnly: false,
-      allowEmpty: false,
-      allowStaticOnly: false,
-      allowWithDecorator: false,
+        allowConstructorOnly: false,
+        allowEmpty: false,
+        allowStaticOnly: false,
+        allowWithDecorator: false,
       },
     ],
 

--- a/rules/@typescript-eslint.js
+++ b/rules/@typescript-eslint.js
@@ -44,18 +44,7 @@ module.exports = {
     // This rule bans specific types and can suggest alternatives. It does not ban the corresponding runtime objects from being used.
     // It includes a default set of types that are probably mistakes, like using 'String' instead of 'string'.
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/ban-types.md
-    '@typescript-eslint/ban-types': [
-      'error',
-      {
-        types: {
-          '{}': {
-            message: "Use 'object' instead",
-            fixWith: 'object',
-          },
-        },
-        extendDefaults: true,
-      },
-    ],
+    '@typescript-eslint/ban-types': 'error',
 
     // Ensures that literals on classes are exposed in a consistent style.
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/class-literal-property-style.md


### PR DESCRIPTION
## High Level Overview of Change

Upgrade `@typescript-eslint` to 3.0.0

- Remove options from rules that are now unused
- Just use the new defaults for the `ban-types` rule
- Fix the `StrictPascalCase` bug for enum members
- Change severity of some rules to match the recommended sets
- Rename a rule option to match the new name
- Add some TODOs


## Test Plan

- Ran `npm link` against `payid` and `xpring-common-js` and it looked mostly good (although it did yell at me for using a "too new" version of TypeScript).

<!--
## Future Tasks
For future tasks related to PR.
-->
