### PR TITLE
0.3.1 - Change `array-type` rule configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [Unreleased]
 
+## 0.3.1 - May 26, 2020
+
+- Change config for `@typescript-eslint/array-type`
+  - Use `Array<T>` for complex types like unions / intersections
+
 ## 0.3.0 - May 26, 2020
 
 - Upgrade `@typescript-eslint` to 3.0.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Xpring's base TS ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {

--- a/rules/@typescript-eslint.js
+++ b/rules/@typescript-eslint.js
@@ -20,8 +20,8 @@ module.exports = {
     '@typescript-eslint/array-type': [
       'error',
       {
-        default: 'array',
-        readonly: 'array',
+        default: 'array-simple',
+        readonly: 'array-simple',
       },
     ],
 


### PR DESCRIPTION
## High Level Overview of Change

- Change config for `@typescript-eslint/array-type`
  - Use `Array<T>` for complex types like unions / intersections

### Context of Change

It looks really awful to do something like `const ids: readonly (string | null)[] = ...`

It looks better to do `const ids: ReadonlyArray<string | null> = ...`

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

## Test Plan

Ran `npm link` with `payid` to test this change.

<!--
## Future Tasks
For future tasks related to PR.
-->
