### PR TITLE
0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [Unreleased]
 
+## 0.3.2 - May 27, 2020
+
+- Add an exception to our `naming-convention` rule
+
+`rippled` uses casing of object property names to indicate whether a property is calculated or "real". So, we need to allow `PascalCase` property names when we use `gRPC`. The way this is currently implemented is an override for all `*.ts` files that live in a `/XRP/` directory.
+
 ## 0.3.1 - May 26, 2020
 
 - Change config for `@typescript-eslint/array-type`

--- a/loose.js
+++ b/loose.js
@@ -21,7 +21,7 @@ module.exports = {
     // TODO: Definitely remove this one
     'max-params': ['warn', { max: 4 }],
 
-    // Disallows assigning any to variables and properties
+    // Disallows assigning `any` to variables and properties
     '@typescript-eslint/no-unsafe-assignment': 'off',
     // Disallows calling (function calls) on an `any` type value.
     '@typescript-eslint/no-unsafe-call': 'off',
@@ -29,6 +29,7 @@ module.exports = {
     '@typescript-eslint/no-unsafe-member-access': 'off',
     // Disallows returning an `any` type value from a function.
     '@typescript-eslint/no-unsafe-return': 'off',
+
     // This rule aims to standardize the use of type assertion style across the codebase.
     '@typescript-eslint/consistent-type-assertions': [
       'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Xpring's base TS ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {

--- a/rules/@typescript-eslint.js
+++ b/rules/@typescript-eslint.js
@@ -165,7 +165,6 @@ module.exports = {
         selector: 'enumMember',
         format: ['PascalCase', 'UPPER_CASE'],
       },
-      // Allow property names to be snake_case
       {
         selector: 'property',
         format: ['camelCase'],
@@ -740,6 +739,73 @@ module.exports = {
             'ts-ignore': true,
             'ts-nocheck': true,
             'ts-check': false,
+          },
+        ],
+      },
+    },
+    // Exceptions because of rippled's gRPC stuff.
+    {
+      files: ['**/XRP/**/*.ts'],
+      rules: {
+        // rippled uses casing to distinguish calculated vs real property names.
+        // Thus, we need to allow PascalCase property names for some scenarios.
+        '@typescript-eslint/naming-convention': [
+          'warn',
+          {
+            selector: 'default',
+            format: ['camelCase'],
+            leadingUnderscore: 'allow',
+            trailingUnderscore: 'allow',
+          },
+
+          {
+            selector: 'variable',
+            format: ['camelCase', 'UPPER_CASE'],
+            leadingUnderscore: 'allow',
+            trailingUnderscore: 'allow',
+          },
+
+          {
+            selector: 'typeLike',
+            format: ['PascalCase'],
+          },
+          // Enforce that boolean variables are prefixed with an allowed verb.
+          {
+            selector: 'variable',
+            types: ['boolean'],
+            // This isn't really PascalCase, because the prefix gets removed.
+            // So something like "isValidPayID" would get the prefix stripped
+            // and "ValidPayID" is in PascalCase.
+            format: ['PascalCase'],
+            prefix: ['is', 'should', 'has', 'can', 'did', 'will'],
+          },
+          // Enforce that type parameters (generics) are prefixed with T
+          {
+            selector: 'typeParameter',
+            format: ['PascalCase'],
+            prefix: ['T'],
+          },
+          // Enforce that enums are singular, and do not end with 's' (for type theory reasons)
+          {
+            selector: 'enum',
+            format: ['PascalCase'],
+            filter: {
+              regex: 'Status$',
+              match: false,
+            },
+            custom: {
+              regex: 's$',
+              match: false,
+            },
+          },
+          // Enforce that enumMembers are PascalCase
+          {
+            selector: 'enumMember',
+            format: ['PascalCase', 'UPPER_CASE'],
+          },
+          {
+            selector: 'property',
+            format: ['camelCase', 'PascalCase'],
           },
         ],
       },


### PR DESCRIPTION
## High Level Overview of Change

Add an exception to our `naming-convention` rule to support `rippled`'s silly usage of property name casing to indicate calculated vs real properties.