### PR TITLE
v0.5.0 - Add `eslint-plugin-eslint-comments`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [Unreleased]
 
+## 0.5.0 - May 28, 2020
+
+Add `eslint-plugin-eslint-comments` to our linting configuration.
+
+Adds various rules around `/* eslint */` style comments, the most useful of which is requiring that `/* eslint-disable */` comments have comments explaining why you need to disable something.
+
 ## 0.4.0 - May 28, 2020
 
 - Add `eslint-plugin-node` to our linting configuration

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = {
     './rules/eslint-core/variables',
     './rules/eslint-core/style',
     './rules/eslint-core/es6',
+    './rules/eslint-comments',
     './rules/@typescript-eslint',
     './rules/tsdoc',
     './rules/node',

--- a/package-lock.json
+++ b/package-lock.json
@@ -741,6 +741,24 @@
         "regexpp": "^3.0.0"
       }
     },
+    "eslint-plugin-eslint-comments": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.2.0.tgz",
+      "integrity": "sha512-0jkOl0hfojIHHmEHgmNdqv4fmh7300NdpA9FFpF7zaoLvB/QeXOGNLIo86oAveJFrfB1p05kC8hpEMHM8DwWVQ==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5",
+        "ignore": "^5.0.5"
+      },
+      "dependencies": {
+        "ignore": {
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.6.tgz",
+          "integrity": "sha512-cgXgkypZBcCnOgSihyeqbo6gjIaIyDqPQB7Ra4vhE9m6kigdGoQDMHjviFhRZo3IMlRy6yElosoviMs5YxZXUA==",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-import": {
       "version": "2.20.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.2.tgz",
@@ -2150,6 +2168,12 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
+    "typescript": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
+      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -43,11 +43,13 @@
     "@typescript-eslint/parser": "^3.0.1",
     "eslint": "^7.0.0",
     "eslint-find-rules": "^3.4.0",
+    "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-mocha": "^7.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-tsdoc": "^0.2.5",
-    "prettier": "^2.0.5"
+    "prettier": "^2.0.5",
+    "typescript": "^3.9.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Xpring's base TS ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {

--- a/rules/eslint-comments.js
+++ b/rules/eslint-comments.js
@@ -1,0 +1,62 @@
+module.exports = {
+  env: {
+    node: true, // Enable node global variables & Node.js scoping
+    es2020: true, // Add all ECMAScript 2020 globals and automatically set the ecmaVersion parser option to ES2020
+  },
+  parserOptions: {
+    sourceType: 'module',
+  },
+
+  plugins: ['eslint-comments'],
+  rules: {
+    /* BEST PRACTICES */
+
+    // Require a eslint-enable comment for every eslint-disable comment
+    // https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/disable-enable-pair.html
+    'eslint-comments/disable-enable-pair': ['error', { allowWholeFile: true }],
+
+    // Disallow a eslint-enable comment for multiple eslint-disable comments
+    // https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-aggregating-enable.html
+    // TODO: Disable this rule?
+    'eslint-comments/no-aggregating-enable': 'error',
+
+    // Disallow duplicate eslint-disable comments
+    // https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-duplicate-disable.html
+    'eslint-comments/no-duplicate-disable': 'error',
+
+    // Disallow eslint-disable comments without rule names
+    // https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-unlimited-disable.html
+    'eslint-comments/no-unlimited-disable': 'error',
+
+    // Disallow unused eslint-disable comments
+    // https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-unused-disable.html
+    'eslint-comments/no-unused-disable': 'error',
+
+    // Disallow unused eslint-enable comments
+    // https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-unused-enable.html
+    'eslint-comments/no-unused-enable': 'error',
+
+    /* STYLISTIC ISSUES */
+
+    // Disallow ESLint directive-comments
+    // https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-use.html
+    'eslint-comments/no-use': [
+      'error',
+      {
+        allow: ['eslint-enable', 'eslint-disable', 'eslint-disable-next-line'],
+      },
+    ],
+
+    // Require include descriptions in ESLint directive-comments
+    'eslint-comments/require-description': ['error', { ignore: [] }],
+
+    /* DISABLED RULES */
+
+    // Disallow eslint-disable comments about specific rules
+    // https://mysticatea.github.io/eslint-plugin-eslint-comments/rules/no-restricted-disable.html
+    // This rule could be useful if we wanted to make it impossible to disable certain rules
+    'eslint-comments/no-restricted-disable': 'off',
+  },
+
+  overrides: [],
+}

--- a/rules/eslint-comments.js
+++ b/rules/eslint-comments.js
@@ -48,7 +48,7 @@ module.exports = {
     ],
 
     // Require include descriptions in ESLint directive-comments
-    'eslint-comments/require-description': ['error', { ignore: [] }],
+    'eslint-comments/require-description': ['error', { ignore: ['eslint-enable'] }],
 
     /* DISABLED RULES */
 


### PR DESCRIPTION
## High Level Overview of Change

Add `eslint-plugin-eslint-comments` to our linting configuration.

Adds various rules around `/* eslint */` style comments, the most useful of which is requiring that `/* eslint-disable */` comments have comments explaining why you need to disable something.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [x] Release

## Test Plan

Ran `npm link` with `payid` and `xpring-common-js`.

<!--
## Future Tasks
For future tasks related to PR.
-->
