### PR TITLE
v0.6.1 - No hyphens after `@returns` in JSDoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [Unreleased]
 
+## 0.6.1 - JUNE 2, 2020
+
+- Upgrade `eslint-plugin-jsdoc` to `v27.0.0`, to enforce not using hyphens between a `@returns` tag and its description.
+
 ## 0.6.0 - June 2, 2020
 
 Add `eslint-plugin-jsdoc` as a peer dependency, to enforce JSDoc comments for functions and classes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -402,9 +402,9 @@
       "dev": true
     },
     "comment-parser": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.4.tgz",
-      "integrity": "sha512-Nnl77/mt6sj1BiYSVMeMWzvD0183F2MFOJyFRmZHimUVDYS9J40AvXpiFA7RpU5pQH+HkvYc0dnsHpwW2xmbyQ==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.5.tgz",
+      "integrity": "sha512-iH9YA35ccw94nx5244GVkpyC9eVTsL71jZz6iz5w6RIf79JLF2AsXHXq9p6Oaohyl3sx5qSMnGsWUDFIAfWL4w==",
       "dev": true
     },
     "concat-map": {
@@ -786,9 +786,9 @@
       }
     },
     "eslint-plugin-jsdoc": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-26.0.0.tgz",
-      "integrity": "sha512-/oEywHPBn6eVDExTgDTwdwyQlVIuJziovXOPXBROW8yW93vk6/IGezW5jbzmA2pX4tVRCQc/jz5/mZea+FCmfw==",
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-27.0.0.tgz",
+      "integrity": "sha512-cgojh/+T8JNB3yBmLerFZz/md+h9rQgmz0qCbeezlPoS5eSMAzsTl3io4Ac4N9Z6o/6ilDKzmqwJHw0Z21RYKg==",
       "dev": true,
       "requires": {
         "comment-parser": "^0.7.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Xpring's base TS ESLint config, following our styleguide",
   "main": "index.js",
   "scripts": {
@@ -32,7 +32,7 @@
     "eslint": ">= 7",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-jsdoc": "^26.0.0",
+    "eslint-plugin-jsdoc": "^27.0.0",
     "eslint-plugin-mocha": "^7.0.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.3",
@@ -47,7 +47,7 @@
     "eslint-find-rules": "^3.4.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-jsdoc": "^26.0.0",
+    "eslint-plugin-jsdoc": "^27.0.0",
     "eslint-plugin-mocha": "^7.0.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.3",

--- a/rules/jsdoc.js
+++ b/rules/jsdoc.js
@@ -139,7 +139,10 @@ module.exports = {
       'error',
       'always',
       {
-        checkProperties: true,
+        tags: {
+          '*': 'never',
+          property: 'always',
+        },
       },
     ],
 


### PR DESCRIPTION
## High Level Overview of Change

Upgrades `eslint-plugin-jsdoc` and modifies a rule to disallow hyphens between a `@returns` tag and its description.