### PR TITLE
0.6.3 - Disable some rules for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [Unreleased]
 
+## 0.6.3 - June 8, 2020
+
+- Disable some rules specifically for `*.test.ts` files
+
+- Allow an "unscoped `this`" keyword, as Mocha lets you do `this.timeout(num)` to set a test-specific timeout.
+- Allow using the `var!` syntax to make non-null assertions in test files, so we don't have to deal with the `null | undefined` case in test files when we _know_ the result will be valid.
+
 ## 0.6.2 - June 8, 2020
 
 - Upgrade `eslint-plugin-import` to one that officially supports ESLint v7.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,44 +1,30 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Xpring's base TS ESLint config, following our styleguide",
-  "main": "index.js",
-  "scripts": {
-    "eslint-find-option-rules": "eslint-find-rules [option] <file> [flag]",
-    "unused": "eslint-find-rules --unused",
-    "plugin": "eslint-find-rules --plugin",
-    "check-prettier": "npx eslint --print-config index.js | npx eslint-config-prettier-check",
-    "check-prettier-test": "npx eslint --print-config test/index.test.js | npx eslint-config-prettier-check",
-    "lint": "eslint --report-unused-disable-directives ."
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/xpring-eng/eslint"
-  },
   "keywords": [
     "eslint",
     "eslintconfig",
     "config",
     "styleguide"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/xpring-eng/eslint"
+  },
   "license": "MIT",
+  "main": "index.js",
+  "scripts": {
+    "check-prettier": "npx eslint --print-config index.js | npx eslint-config-prettier-check",
+    "check-prettier-test": "npx eslint --print-config test/index.test.js | npx eslint-config-prettier-check",
+    "eslint-find-option-rules": "eslint-find-rules [option] <file> [flag]",
+    "lint": "eslint --report-unused-disable-directives .",
+    "plugin": "eslint-find-rules --plugin",
+    "unused": "eslint-find-rules --unused"
+  },
   "dependencies": {
     "confusing-browser-globals": "^1.0.9",
     "eslint-config-prettier": "^6.11.0"
-  },
-  "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.1.0",
-    "@typescript-eslint/parser": "^3.1.0",
-    "eslint": ">= 7",
-    "eslint-plugin-eslint-comments": "^3.2.0",
-    "eslint-plugin-import": "^2.21.1",
-    "eslint-plugin-jsdoc": "^27.0.0",
-    "eslint-plugin-mocha": "^7.0.1",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^3.1.3",
-    "eslint-plugin-tsdoc": "^0.2.5",
-    "prettier": "^2.0.5",
-    "typescript": "^3.9.2"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.1.0",
@@ -54,5 +40,19 @@
     "eslint-plugin-tsdoc": "^0.2.5",
     "prettier": "^2.0.5",
     "typescript": "^3.9.3"
+  },
+  "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": "^3.1.0",
+    "@typescript-eslint/parser": "^3.1.0",
+    "eslint": ">= 7",
+    "eslint-plugin-eslint-comments": "^3.2.0",
+    "eslint-plugin-import": "^2.21.1",
+    "eslint-plugin-jsdoc": "^27.0.0",
+    "eslint-plugin-mocha": "^7.0.1",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-prettier": "^3.1.3",
+    "eslint-plugin-tsdoc": "^0.2.5",
+    "prettier": "^2.0.5",
+    "typescript": "^3.9.2"
   }
 }

--- a/rules/@typescript-eslint.js
+++ b/rules/@typescript-eslint.js
@@ -732,6 +732,12 @@ module.exports = {
         // TODO:(hbergren) Is this true?
         '@typescript-eslint/no-floating-promises': 'off',
 
+        // In Mocha, you can use `this.timeout()` to set a custom timeout for a specific test
+        '@typescript-eslint/no-invalid-this': 'off',
+
+        // We use non-null assertions liberally in tests to allow TypeScript to build
+        '@typescript-eslint/no-non-null-assertion': 'off',
+
         // We purposefully break some TypeScript assumptions in various tests (like giving `null` to a database access function)
         '@typescript-eslint/ban-ts-comment': [
           'error',


### PR DESCRIPTION
Disable some rules specifically for `*.test.ts` files

- Allow an "unscoped `this`" keyword, as Mocha lets you do `this.timeout(num)` to set a test-specific timeout.
- Allow using the `var!` syntax to make non-null assertions in test files, so we don't have to deal with the `null | undefined` case in test files when we _know_ the result will be valid.
