### PR TITLE
0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [Unreleased]
 
+## 0.9.2 - July 9, 2020
+
+- Allow `was` as a prefix for boolean variables
+
 ## 0.9.1 - July 8, 2020
 
 - Update `typescript-eslint` and `eslint-plugin-jsdoc`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xpring-eng/eslint-config-base",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Xpring's base TS ESLint config, following our styleguide",
   "keywords": [
     "eslint",

--- a/rules/@typescript-eslint.js
+++ b/rules/@typescript-eslint.js
@@ -811,7 +811,7 @@ module.exports = {
             // So something like "isValidPayID" would get the prefix stripped
             // and "ValidPayID" is in PascalCase.
             format: ['PascalCase'],
-            prefix: ['is', 'should', 'has', 'can', 'did', 'does', 'will'],
+            prefix: ['is', 'was', 'should', 'has', 'can', 'did', 'does', 'will'],
           },
           // Enforce that type parameters (generics) are prefixed with T
           {


### PR DESCRIPTION
## High Level Overview of Change

- Allow `was` as a prefix for boolean variables
